### PR TITLE
chore: add repo governance files (SECURITY.md, CHANGELOG.md, CI, Dependabot)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest version receives security updates.
+
+| Version | Supported |
+|---------|-----------|
+| latest  | ✅        |
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities via [GitHub Security Advisories](../../security/advisories/new).
+
+**Do not open public issues for security vulnerabilities.**
+
+We aim to respond within 48 hours and will keep you informed throughout the process.


### PR DESCRIPTION
## Repo Governance Standardization

This PR adds missing governance and CI files as part of the MCP Platform standardization initiative ([REQ-020](https://github.com/jon-the-dev/domain-lookup-mcp-server)).

### Files Added

- `.github/dependabot.yml`
- `CHANGELOG.md`
- `SECURITY.md`

### Why

These files are required for the MCP hosted marketplace:
- **SECURITY.md** — vulnerability disclosure policy
- **CHANGELOG.md** — semantic versioning history
- **CI workflow** — lint, type-check, test gates
- **dependabot.yml** — automated dependency updates

Part of sprint 3 standardization across all 17 MCP server repos.
